### PR TITLE
feat: add filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,28 @@ const { shouldSkipTraversal, shouldSkipContent } = require('./ignore');
 program
   .argument('<folderPath>', 'Path to the target folder')
   .argument('[outputName]', 'Output file name (optional)')
+  .option('-f, --filter <patterns>', 'Padrões adicionais para filtrar (separados por vírgula)')
   .parse();
 
 const [folderPath] = program.args;
+const options = program.opts();
+const additionalFilters = options.filter ? options.filter.split(',').map(p => p.trim()) : [];
+
+const originalSkipTraversal = shouldSkipTraversal;
+const shouldSkipTraversalWithFilters = (filepath) => {
+  if (originalSkipTraversal(filepath)) {
+    return true;
+  }
+
+  const normalizedPath = filepath.replace(/\\/g, '/');
+  return additionalFilters.some(pattern => {
+    const regexPattern = pattern.includes('/') 
+      ? pattern.replace(/\//g, '[/\\\\]') 
+      : `(^|[/\\\\])${pattern}($|[/\\\\])`;
+    
+    return new RegExp(regexPattern).test(normalizedPath);
+  });
+};
 
 let totalFiles = 0;
 let totalSize = 0;
@@ -30,7 +49,7 @@ async function generateTree(dir, prefix = '', includedFiles = new Set()) {
     const itemPath = path.join(dir, item);
     const stats = await fs.stat(itemPath);
     
-    if (shouldSkipTraversal(itemPath)) continue;
+    if (shouldSkipTraversalWithFilters(itemPath)) continue;
     
     const isLast = i === items.length - 1;
     const connector = isLast ? '└── ' : '├── ';
@@ -55,7 +74,7 @@ async function getAllFiles(dir) {
   
   for (const item of items) {
     const fullPath = path.join(dir, item);
-    if (shouldSkipTraversal(fullPath)) continue;
+    if (shouldSkipTraversalWithFilters(fullPath)) continue;
     
     const stats = await fs.stat(fullPath);
     

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { shouldSkipTraversal, shouldSkipContent } = require('./ignore');
 program
   .argument('<folderPath>', 'Path to the target folder')
   .argument('[outputName]', 'Output file name (optional)')
-  .option('-f, --filter <patterns>', 'Padrões adicionais para filtrar (separados por vírgula)')
+  .option('-f, --filter <patterns>', 'Additional patterns to filter (separated by commas)')
   .parse();
 
 const [folderPath] = program.args;


### PR DESCRIPTION
# Add Custom Filter Option to CLI

## Changes
- Added a new CLI option `-f, --filter` that allows users to specify additional patterns to exclude from traversal
- Implemented pattern filtering using the same logic as the existing ignore system
- Maintains backward compatibility with all existing ignore rules

## Features
- Filter multiple patterns using comma-separated values
- Supports both simple names and path-based patterns
- Works alongside the existing ignore.js rules

## Usage Examples
### Filter out specific folders
```node cli.js ./my-project --filter "tests,docs"```

### Filter with path patterns
```node cli.js ./my-project --filter "src/tests,src/docs"```

### Combined with output file name
```node cli.js ./my-project output.txt --filter "tests,examples,temp"```

## Technical Details
- Implemented as a wrapper around the existing `shouldSkipTraversal` function
- Uses the same path normalization and pattern matching logic as the original implementation
- Patterns can be specified with or without forward slashes
- All original ignore rules from `ignore.js` are still applied first

## Testing
Please test the following scenarios:
- Basic folder traversal without filters
- Single pattern filtering
- Multiple pattern filtering
- Path-based pattern filtering
- Combination with existing ignore rules